### PR TITLE
fix handling of registration and receiving push notifications

### DIFF
--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -122,10 +122,14 @@
     [Localytics tagScreen:payload.name];
 }
 
-- (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
-                                              options:(NSDictionary *)options
+- (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     [Localytics setPushToken:deviceToken];
+}
+
+- (void)receivedRemoteNotification:(NSDictionary *)userInfo
+{
+    [Localytics handlePushNotificationOpened:userInfo];
 }
 
 - (void)flush


### PR DESCRIPTION
Using the latest version of the segment Analytics iOS library, the following method never gets called:

-- (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
-                                              options:(NSDictionary *)options

Replace this with:

- (void)receivedRemoteNotification:(NSDictionary *)userInfo

Also add in handling of receipt of remote notification:

- (void)receivedRemoteNotification:(NSDictionary *)userInfo
