### PR TITLE
Add/attribute scope setting

### DIFF
--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -65,7 +65,6 @@
         attributeScope = LLProfileScopeApplication;
     }
     
-    
     // Other traits. Iterate over all the traits and set them.
     for (NSString *key in payload.traits) {
         NSString *traitValue =

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -14,8 +14,6 @@
         NSString *appKey = [settings objectForKey:@"appKey"];
         [Localytics integrate:appKey];
         
-        [Localytics setLoggingEnabled:YES];
-        
         NSNumber *sessionTimeoutInterval = [settings objectForKey:@"sessionTimeoutInterval"];
         if (sessionTimeoutInterval != nil &&
             [sessionTimeoutInterval floatValue] > 0) {
@@ -59,7 +57,7 @@
     
     // Allow users to specify whether attributes should be Org or Application Scoped.
     NSInteger attributeScope;
-    if ([self.settings objectForKey:@"organizationScope"]) {
+    if ([self setOrganizationScope]) {
         attributeScope = LLProfileScopeOrganization;
     } else {
         attributeScope = LLProfileScopeApplication;
@@ -140,6 +138,11 @@
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo
 {
     [Localytics handleNotification:userInfo];
+}
+
+- (BOOL)setOrganizationScope
+{
+    return [(NSNumber *)[self.settings objectForKey:@"setOrganizationScope"] boolValue];
 }
 
 - (void)flush

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -14,6 +14,8 @@
         NSString *appKey = [settings objectForKey:@"appKey"];
         [Localytics integrate:appKey];
         
+        [Localytics setLoggingEnabled:YES];
+        
         NSNumber *sessionTimeoutInterval = [settings objectForKey:@"sessionTimeoutInterval"];
         if (sessionTimeoutInterval != nil &&
             [sessionTimeoutInterval floatValue] > 0) {
@@ -55,13 +57,22 @@
     
     [self setCustomDimensions:payload.traits];
     
+    // Allow users to specify whether attributes should be Org or Application Scoped.
+    NSInteger attributeScope;
+    if ([self.settings objectForKey:@"organizationScope"]) {
+        attributeScope = LLProfileScopeOrganization;
+    } else {
+        attributeScope = LLProfileScopeApplication;
+    }
+    
+    
     // Other traits. Iterate over all the traits and set them.
     for (NSString *key in payload.traits) {
         NSString *traitValue =
         [NSString stringWithFormat:@"%@", [payload.traits objectForKey:key]];
         [Localytics setValue:traitValue
                    forProfileAttribute:key
-                             withScope:LLProfileScopeApplication];
+                             withScope:attributeScope];
     }
 }
 


### PR DESCRIPTION
Localytics allows customers to set attributes at an application and organization level.
https://docs.localytics.com/dev/ios.html#profiles-ios

This affects how these attributes can be used in Localytics to create audiences.

> Each time you set the value of a profile attribute, you can set the scope to "app-level" or "org-level". App-level profile attributes are only stored in relation to that specific Localytics app key, so they can only be used for building audiences for that one app. Org-level profile attributes are available to all apps in the org, so they can be used across multiple Localytics app keys, which might represent the same app on a different platform or multiple apps produced by your company.

Previously we set all attributes as application level, this change makes it so that customers can decide whether the traits will be scoped at an application or organization level by checking a boolean in the Localytics settings. If unchecked, we default to application scope which is the native default behavior of the SDK.

@f2prateek 