### PR TITLE
Bumps Localytics to 4.3.1

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Analytics (3.2.4)
+  - Analytics (3.6.0)
   - Expecta (1.0.5)
-  - Localytics (4.0.0)
-  - Segment-Localytics (1.0.3):
+  - Localytics (4.3.1)
+  - Segment-Localytics (1.0.5.beta):
     - Analytics (~> 3.0)
-    - Localytics (~> 4.0)
-  - Specta (1.0.5)
+    - Localytics (~> 4.3.1)
+  - Specta (1.0.6)
 
 DEPENDENCIES:
   - Expecta
@@ -14,15 +14,15 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Segment-Localytics:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Analytics: d801f32615853ca3108216423dbaa829c74f5927
+  Analytics: 15be3e651d22cc811f44df65698538236676437b
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  Localytics: 205a563a2761b5d844e8bba522d3c1da6cf4bc5b
-  Segment-Localytics: 2ecf2617fb6f22d451075d66b1bfda9c44c003f7
-  Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
+  Localytics: 94bd0ebb8337a2a0fe39e5dc16efcd8712a25c8f
+  Segment-Localytics: 67a5c19568631cbd28a12173923b2b80752ff193
+  Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
 PODFILE CHECKSUM: 7c4e8146b728c1eab3694042b0421d868d6cbba7
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.2.0

--- a/Example/Segment-Localytics.xcodeproj/project.pbxproj
+++ b/Example/Segment-Localytics.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		5C9E1A861D58AA6900EA2013 /* Localytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9E1A841D58AA0600EA2013 /* Localytics.framework */; };
-		5C9E1A881D58AA9400EA2013 /* Localytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9E1A871D58AA9400EA2013 /* Localytics.framework */; };
-		5C9E1A891D58AA9400EA2013 /* Localytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9E1A871D58AA9400EA2013 /* Localytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -45,7 +43,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5C9E1A891D58AA9400EA2013 /* Localytics.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,7 +53,6 @@
 		21E4B12D652AD30FF16F23E6 /* Pods-Segment-Localytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Localytics_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Localytics_Tests/Pods-Segment-Localytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		40DDFBAC33B19BB1D16E0F12 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		5C9E1A841D58AA0600EA2013 /* Localytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Localytics.framework; path = "Pods/Localytics/Localytics-iOS-4.0.0/Localytics.framework"; sourceTree = "<group>"; };
-		5C9E1A871D58AA9400EA2013 /* Localytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Localytics.framework; path = "Pods/Localytics/Localytics-iOS-4.0.0/Localytics.framework"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Segment-Localytics_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Segment-Localytics_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -94,7 +90,6 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				5C9E1A861D58AA6900EA2013 /* Localytics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
-				5C9E1A881D58AA9400EA2013 /* Localytics.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
 				70CA2D8753AB163AD7F85D92 /* libPods-Segment-Localytics_Example.a in Frameworks */,
 			);
@@ -117,7 +112,6 @@
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
-				5C9E1A871D58AA9400EA2013 /* Localytics.framework */,
 				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
 				6003F593195388D20070C39A /* Example for Segment-Localytics */,
 				6003F5B5195388D20070C39A /* Tests */,
@@ -359,7 +353,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9397663B5C1C7B0D0C76BBCF /* [CP] Copy Pods Resources */ = {
@@ -389,7 +383,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		C64E3CFE812D13032B48C7D0 /* [CP] Embed Pods Frameworks */ = {

--- a/Segment-Localytics.podspec
+++ b/Segment-Localytics.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'Localytics', '~> 4.0'
+  s.dependency 'Localytics', '~> 4.3.1'
 end


### PR DESCRIPTION
Requested by Aaptiv, Localytics is on [4.3.1](https://cocoapods.org/?q=localytics), and Aaptiv would like to ensure that we are depending on the latest. 

iOS Updates (4.0 > 4.3) include:

- Fixed an issue that could cause a crash when Places is enabled in the Dashboard but Places integration has not been completed.
- Fixed an issue that was caused when file protection is enabled globally for an app.
- Fixed a bug that caused places identifiers with quotes to not be handled appropriately.
- Fixed a bug where standard events would log transactions with a customer value of 0

.