### PR TITLE
Maps/reserved traits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PROJECT := Segment-Localytics
 XC_ARGS := -scheme $(PROJECT)-Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 
 install: Example/Podfile Segment-Localytics.podspec
+	pod repo update
 	pod install --project-directory=Example
 
 clean:

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -40,7 +40,7 @@
 {
     if (payload.userId) {
         [Localytics setCustomerId:payload.userId];
-        SEGLog(@"[Localytics setCustomerId:payload.userId];", payload.userId);
+        SEGLog(@"[Localytics setCustomerId:%@];", payload.userId);
     }
     
     NSString *email = [payload.traits objectForKey:@"email"];
@@ -49,7 +49,7 @@
         SEGLog(@"[Localytics setValue:%@ forIdentifier:@'email']", email);
         
         [Localytics setCustomerEmail:email];
-        SEGLog(@"[Localytics setCustomerEmail:email];", email);
+        SEGLog(@"[Localytics setCustomerEmail:%@];", email);
     }
     
     NSString *name = [payload.traits objectForKey:@"name"];
@@ -70,7 +70,7 @@
     NSString *lastName = [payload.traits objectForKey:@"last_name"];
     if (lastName) {
         [Localytics setCustomerLastName:lastName];
-        SEGLog(@"[Localytics setCustomerLastName:lastName];", lastName);
+        SEGLog(@"[Localytics setCustomerLastName:%@];", lastName);
     }
     
     [self setCustomDimensions:payload.traits];

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -40,17 +40,37 @@
 {
     if (payload.userId) {
         [Localytics setCustomerId:payload.userId];
+        SEGLog(@"[Localytics setCustomerId:payload.userId];", payload.userId);
     }
     
     NSString *email = [payload.traits objectForKey:@"email"];
     if (email) {
         [Localytics setValue:email forIdentifier:@"email"];
+        SEGLog(@"[Localytics setValue:%@ forIdentifier:@'email']", email);
+        
+        [Localytics setCustomerEmail:email];
+        SEGLog(@"[Localytics setCustomerEmail:email];", email);
     }
     
     NSString *name = [payload.traits objectForKey:@"name"];
-    // TODO support first name, last name?
     if (name) {
         [Localytics setValue:name forIdentifier:@"customer_name"];
+        SEGLog(@"[Localytics setValue:%@ forIdentifier:@'customer_name']", name);
+        
+        [Localytics setCustomerFullName:name];
+        SEGLog(@"[Localytics setCustomerFullName:%@];", name);
+    }
+    
+    NSString *firstName = [payload.traits objectForKey:@"first_name"];
+    if (firstName) {
+        [Localytics setCustomerFirstName:firstName];
+        SEGLog(@"[Localytics setCustomerFirstName:%@];", firstName);
+    }
+    
+    NSString *lastName = [payload.traits objectForKey:@"last_name"];
+    if (lastName) {
+        [Localytics setCustomerLastName:lastName];
+        SEGLog(@"[Localytics setCustomerLastName:lastName];", lastName);
     }
     
     [self setCustomDimensions:payload.traits];


### PR DESCRIPTION
Set reserved Org level traits to Localytics via:

```
[Localytics setCustomerFirstName:@"John"];
[Localytics setCustomerLastName:@"Smith"];
[Localytics setCustomerFullName:@"Sir John Smith, III"];
[Localytics setCustomerEmail:@"sir.john@smith.com"];
```
Keeping current behavior mapping to `email` as well so this will not be a breaking change (i.e. some users may have Audiences/reports built off of those traits). These reserved traits are used to create personalized emails, where the general custom traits cannot.

[Reference](https://docs.localytics.com/dev/ios.html#setting-user-first-name-ios)
Urgent for Xoom: [JIRA](https://segment.atlassian.net/browse/PLATFORM-1200)

Also ran formatter, and of course forever waiting for Travis. Canceled one build.