### PR TITLE
Dispatch openSession on main thread

### DIFF
--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -59,7 +59,7 @@
 
     NSString *email = [payload.traits objectForKey:@"email"];
     if (email) {
-        // Avoid calling this on the main thread
+        // Localytics documents to avoid calling this on the main thread. While we dispatch other methods onto the main thread, this must not be dispatched. Analytics-ios calls `identify` on a background thread, but if that changes in the future, we may have to change this as well
         [Localytics setValue:email forIdentifier:@"email"];
         SEGLog(@"[Localytics setValue:%@ forIdentifier:@'email']", email);
 

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -129,39 +129,32 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
-    // TODO add support for value
-
-    // Backgrounded? Restart the session to add this event.
-    __block BOOL isBackgrounded = @NO;
     [self runOnMainThread:^{
-        isBackgrounded = [[UIApplication sharedApplication] applicationState] !=
-            UIApplicationStateActive;
-    }];
+        // TODO add support for value
 
-    if (isBackgrounded) {
-        // It is recommended that this call be placed in applicationDidBecomeActive
-        [self runOnMainThread:^{
+        // Backgrounded? Restart the session to add this event.
+        BOOL isBackgrounded = [[UIApplication sharedApplication] applicationState] != UIApplicationStateActive;
+        if (isBackgrounded) {
+            // It is recommended that this call be placed in applicationDidBecomeActive
             [Localytics openSession];
-        }];
-    }
+        }
 
-    NSNumber *revenue = [SEGLocalyticsIntegration extractRevenue:payload.properties withKey:@"revenue"];
-    if (revenue) {
-        [Localytics tagEvent:payload.event
-                       attributes:payload.properties
-            customerValueIncrease:@([revenue intValue] * 100)];
-    } else {
-        [Localytics tagEvent:payload.event attributes:payload.properties];
-    }
+        NSNumber *revenue = [SEGLocalyticsIntegration extractRevenue:payload.properties withKey:@"revenue"];
+        if (revenue) {
+            [Localytics tagEvent:payload.event
+                           attributes:payload.properties
+                customerValueIncrease:@([revenue intValue] * 100)];
+        } else {
+            [Localytics tagEvent:payload.event attributes:payload.properties];
+        }
 
-    [self setCustomDimensions:payload.properties];
+        [self setCustomDimensions:payload.properties];
 
-    // Backgrounded? Close the session again after the event.
-    if (isBackgrounded) {
-        [self runOnMainThread:^{
+        // Backgrounded? Close the session again after the event.
+        if (isBackgrounded) {
             [Localytics closeSession];
-        }];
-    }
+        }
+    }];
 }
 
 - (void)screen:(SEGScreenPayload *)payload

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -59,6 +59,7 @@
 
     NSString *email = [payload.traits objectForKey:@"email"];
     if (email) {
+        // Avoid calling this on the main thread
         [Localytics setValue:email forIdentifier:@"email"];
         SEGLog(@"[Localytics setValue:%@ forIdentifier:@'email']", email);
 
@@ -139,7 +140,14 @@
     BOOL isBackgrounded = [[UIApplication sharedApplication] applicationState] !=
         UIApplicationStateActive;
     if (isBackgrounded) {
-        [Localytics openSession];
+        // It is recommended that this call be placed in applicationDidBecomeActive
+        if ([NSThread isMainThread]) {
+            [Localytics openSession];
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [Localytics openSession];
+            });
+        }
     }
 
     NSNumber *revenue = [SEGLocalyticsIntegration extractRevenue:payload.properties withKey:@"revenue"];

--- a/Pod/Classes/SEGLocalyticsIntegration.m
+++ b/Pod/Classes/SEGLocalyticsIntegration.m
@@ -137,8 +137,12 @@
     // TODO add support for value
 
     // Backgrounded? Restart the session to add this event.
-    BOOL isBackgrounded = [[UIApplication sharedApplication] applicationState] !=
-        UIApplicationStateActive;
+    __block BOOL isBackgrounded = @NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        isBackgrounded = [[UIApplication sharedApplication] applicationState] !=
+            UIApplicationStateActive;
+    });
+
     if (isBackgrounded) {
         // It is recommended that this call be placed in applicationDidBecomeActive
         if ([NSThread isMainThread]) {


### PR DESCRIPTION
After looking through Localytics documentation, I don't see explicit cases to dispatch all methods onto the Main Thread. Localytics has made it clear that the following **does not** get dispatched onto the Main Thread: `setValue`, `customerId`, `valueForCustomDimension`, `valueForIdentifier`.

I've added a check for `[Localytics openSession];` as this has explicit instructions to be placed in `applicationDidBecomeActive`, and was an issue surfaced by @divbyzero in issue #18 

I've reached out to Localytics directly as well to ensure that I haven't missed other places where I need to implement this check.