### PR TITLE
Removes version-pinning on Localytics dependency.

### DIFF
--- a/Segment-Localytics.podspec
+++ b/Segment-Localytics.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics'
-  s.dependency 'Localytics', '~> 5.0'
+  s.dependency 'Localytics'
 end


### PR DESCRIPTION
- In order to update to latest Localytics library 6.1.0, version pinning
to version 5 needs to be removed.